### PR TITLE
exception rises for yaml runscripts with tabs

### DIFF
--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -14,6 +14,11 @@ class EsmConfigFileError(Exception):
     This error occurs mainly when there are tabs inside a yaml file. This
     exception returns a user-friendly message indicating where the tabs
     are located in the yaml file.
+
+    Parameters
+    ----------
+    fpath : str
+        Path to the yaml file
     """
 
     def __init__(self, fpath):
@@ -47,6 +52,11 @@ def yaml_file_to_dict(filepath):
     -------
     dict
         A dictionary representation of the yaml file.
+
+    Raises
+    ------
+    EsmConfigFileError
+        Raised when YAML file contains tabs.
     """
     for extension in YAML_AUTO_EXTENSIONS:
         try:

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -57,6 +57,8 @@ def yaml_file_to_dict(filepath):
     ------
     EsmConfigFileError
         Raised when YAML file contains tabs.
+    FileNotFoundError
+        Raised when the YAML file cannot be found and all extensions have been tried.
     """
     for extension in YAML_AUTO_EXTENSIONS:
         try:

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -6,12 +6,37 @@ DEBUG_MODE = logger.level == logging.DEBUG
 
 YAML_AUTO_EXTENSIONS = ["", ".yml", ".yaml", ".YML", ".YAML"]
 
+class EsmConfigFileError(Exception):
+    """
+    Exception for yaml file containing tabs.
+
+    An exception used when yaml.load() throws a yaml.scanner.ScannerError.
+    This error occurs mainly when there are tabs inside a yaml file. This
+    exception returns a user-friendly message indicating where the tabs
+    are located in the yaml file.
+    """
+
+    def __init__(self, fpath):
+        report = ""
+        # Loop through the lines inside the yaml file searching for tabs
+        with open(fpath) as yaml_file:
+            for n, line in enumerate(yaml_file):
+                # Save lines and line numbers with tabs
+                if "\t" in line:
+                    report += str(n) + ":" + line.replace("\t","____") + "\n"
+
+        # Message to return
+        self.message =  "\n\n\n" \
+                       f"Your file {fpath} has tabs, please use ONLY spaces!\n" \
+                        "Tabs are in following lines:\n" + report
+        super().__init__(self.message)
 
 def yaml_file_to_dict(filepath):
     """
     Given a yaml file, returns a corresponding dictionary.
 
     If you do not give an extension, tries again after appending one.
+    It raises an EsmConfigFileError exception if yaml files contain tabs.
 
     Parameters
     ----------
@@ -33,6 +58,11 @@ def yaml_file_to_dict(filepath):
                 error.errno,
                 filepath + extension,
             )
+        except yaml.scanner.ScannerError as error:
+            logger.debug("Your file %s has tabs, please use only spaces!",
+                filepath + extension,
+            )
+            raise EsmConfigFileError(filepath + extension)
     raise FileNotFoundError(
         "All file extensions tried and none worked for %s" % filepath
     )


### PR DESCRIPTION
Fix for esm-tools/esm_tools#59.
- Working for runscripts and config files.
- The error returns user-friendly information about where the tabs are located in the yaml file.