### PR TITLE
functionality to search for duplicates in yaml files and incompatible _changes added

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "4.2.1"
+__version__ = "4.2.2"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -2158,6 +2158,23 @@ def find_key(d_search, k_search, exc_strings = "", level = "", paths2finds = [],
     return paths2finds
 
 
+def user_error(error_type, error_text):
+    """
+    User-friendly error using ``sys.exit()`` instead of an ``Exception``.
+
+    Parameters
+    ----------
+    error_type : str
+        Error type used for the error heading.
+    text : str
+        Text clarifying the error.
+    """
+    error_title = error_type + " error!"
+    print("\n" + error_title + "\n" + "-" * len(error_title) + "\n")
+    print(error_text)
+    sys.exit()
+
+
 class GeneralConfig(dict):  # pragma: no cover
     """ All configs do this! """
 

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -2071,6 +2071,91 @@ def choose_blocks(config, blackdict={}, isblacklist=True):
     remove_entries_from_chapter_in_config(config, all_names, config, all_names)
     gray_list = gray_list_backup.copy()
 
+
+def find_key(d_search, k_search, exc_strings = "", level = "", paths2finds = [], sep = "."):
+    """
+    Searches for a key inside a nested dictionary. It can search for an
+    integer, or a piece of string. A list of strings can be given as an
+    input to search for keys containing all of them. An additional list
+    of strings can be specified for keys containing them be excluded
+    from the findings. This is a recursive function.
+
+    .. Note::
+       Always define paths2finds, to avoid expansion of this list with
+       consecutive calls.
+
+    Parameters
+    ----------
+    d_search : dict
+        The dictionary to be explored recursively.
+    k_search : list, str, int
+        String, integer or list of strings to be search for in ``d_search``.
+    exc_strings : list, str
+        String or list of strings for keys containing them to be excluded
+        from the finds.
+    level : string
+        String specifying the full path to the currently evaluated
+        dictionary. Each dictionary level in these strings is separated
+        by a ``.``.
+    paths2finds : list
+        List of strings specifying the full path to the found keys in
+        ``d_search``. Each dictionary level in these strings is separated
+        by a the specified string in ``sep`` (default is ``"."``).
+    sep : string
+        String separator used in between each path component in
+        ``paths2finds``.
+
+    Return
+    ------
+    paths2finds : list
+        List of strings specifying the full path to the found keys in
+        ``d_search``. Each dictionary level in these strings is separated
+        by a ``.``.
+    """
+    # Transform input to lists
+    if isinstance(k_search, (str, int)):
+        k_search = [k_search]
+    elif not isinstance(k_search, list):
+        raise Exception("k_search is not a string, a list or a list of strings")
+    if isinstance(exc_strings, str):
+        exc_strings = [exc_strings]
+    elif not isinstance(exc_strings, list):
+        raise Exception("exc_strings is not a string, or a list of strings")
+
+    # Loop over the d_search keys
+    for key in d_search.keys():
+        strings_in_key = True
+        # Check if the key meets the specified requirements
+        for istr in k_search:
+            # key is a string but it does not contained the searched string
+            if isinstance(key, str) and isinstance(istr, str) and istr not in key:
+                strings_in_key &= False
+            # key is an integer but is not equal to the searched integer
+            elif isinstance(key, int) and istr is not key:
+                strings_in_key &= False
+            elif isinstance(key, float) and istr is not key:
+                strings_in_key &= False
+            # key is neither an integer or a string
+            elif not isinstance(key, str) and not isinstance(key, int) and not isinstance(key, float):
+                raise Warning("find_key only supports searches for keys that are string or integers")
+                strings_in_key &= False
+        # Check if the key needs to be excluded
+        for estr in exc_strings:
+            # Nothing to exclude if the key is not a string
+            if isinstance(key, str) and estr in key:
+                strings_in_key &= False
+
+        # If the key meets the criteria, add the path to the paths2finds
+        if strings_in_key:
+            paths2finds.append(level + str(key))
+        # If the key does not meet the criteria, but its value is a dictionary
+        # keep searching inside (recursion).
+        elif not strings_in_key and isinstance(d_search[key], dict):
+            paths2finds = find_key(d_search[key], k_search, exc_strings, level + str(key) + sep, paths2finds)
+
+    return paths2finds
+
+
 class GeneralConfig(dict):  # pragma: no cover
     """ All configs do this! """
 

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -2137,7 +2137,8 @@ def find_key(d_search, k_search, exc_strings = "", level = "", paths2finds = [],
                 strings_in_key &= False
             # key is neither an integer or a string
             elif not isinstance(key, str) and not isinstance(key, int) and not isinstance(key, float):
-                raise Warning("find_key only supports searches for keys that are string or integers")
+                raise Warning("find_key only supports searches for keys that are string, integers," \
+                              "floats and booleans")
                 strings_in_key &= False
         # Check if the key needs to be excluded
         for estr in exc_strings:
@@ -2151,7 +2152,8 @@ def find_key(d_search, k_search, exc_strings = "", level = "", paths2finds = [],
         # If the key does not meet the criteria, but its value is a dictionary
         # keep searching inside (recursion).
         elif not strings_in_key and isinstance(d_search[key], dict):
-            paths2finds = find_key(d_search[key], k_search, exc_strings, level + str(key) + sep, paths2finds)
+            paths2finds = find_key(d_search[key], k_search, exc_strings, level + str(key) + sep,
+                                   paths2finds, sep)
 
     return paths2finds
 

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -173,11 +173,6 @@ def check_changes_duplicates(yamldict_all, fpath):
                                     "    - " + ".".join(other_changes) + "\n" +
                                     "\n" + changes_note + "\n\n")
 
-            # Load the yaml file
-            with open(fpath) as yaml_file:
-                # Loop through the <variable>_changes found in the dictionary
-                for changes in changes_list:
-                    pass
 
 def find_last_choose(var_path):
     """

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -109,20 +109,22 @@ def check_changes_duplicates(yamldict_all, fpath):
             # If more than one ``_changes`` without ``choose_`` return error
             if len(changes_no_choose) > 1:
                 changes_no_choose = [x.replace(",",".") for x in changes_no_choose]
-                raise Exception("\n\nMore than one ``_changes`` out of a ``choose_``in "
-                                + fpath + ":\n    - " + "\n    - ".join(changes_no_choose) +
-                                "\n" + changes_note + "\n\n")
+                esm_parser.user_error("YAML syntax",
+                            "More than one ``_changes`` out of a ``choose_``in "
+                            + fpath + ":\n    - " + "\n    - ".join(changes_no_choose) +
+                            "\n" + changes_note + "\n\n")
             # If only one ``_changes`` without ``choose_`` check for ``_changes`` inside
             # ``choose_`` and return error if any is found
             elif len(changes_no_choose) == 1:
                 changes_group.remove(changes_no_choose[0])
                 if len(changes_group) > 0:
                     changes_group = [x.replace(",",".") for x in changes_group]
-                    raise Exception("\n\nThe general ``" + changes_no_choose[0] +
-                                    "`` and ``_changes`` in ``choose_`` are not compatible in "
-                                    + fpath + ":\n    - " +
-                                    "\n    - ".join(changes_group) + "\n" +
-                                    "\n" + changes_note + "\n\n")
+                    esm_parser.user_error("YAML syntax",
+                                "The general ``" + changes_no_choose[0] +
+                                "`` and ``_changes`` in ``choose_`` are not compatible in "
+                                + fpath + ":\n    - " +
+                                "\n    - ".join(changes_group) + "\n" +
+                                "\n" + changes_note + "\n\n")
 
             # If you reach this point all ``_changes`` are inside
             # some number of ``choose_`` (there are no ``_changes``
@@ -155,19 +157,21 @@ def check_changes_duplicates(yamldict_all, fpath):
                             case = path2choose.replace(sub_path2choose + ",", "") \
                                         .split(",")[0]
                         if case == sub_case:
-                            raise Exception("\n\nThe following ``_changes`` can be accessed " +
-                                         "simultaneously in " + fpath + ":\n" +
-                                         "    - " + ".".join(changes) + "\n" +
-                                         "    - " + ".".join(other_changes) + "\n" +
-                                         "\n" + changes_note + "\n\n")
+                            esm_parser.user_error("YAML syntax",
+                                        "The following ``_changes`` can be accessed " +
+                                        "simultaneously in " + fpath + ":\n" +
+                                        "    - " + ".".join(changes) + "\n" +
+                                        "    - " + ".".join(other_changes) + "\n" +
+                                        "\n" + changes_note + "\n\n")
                     else:
                         # If these ``choose_`` are different they can be accessed
                         # simultaneously, then it returns an error
-                        raise Exception ("\n\nThe following ``_changes`` can be accessed " +
-                                         "simultaneously in " + fpath + ":\n" +
-                                         "    - " + ".".join(changes) + "\n" +
-                                         "    - " + ".".join(other_changes) + "\n" +
-                                         "\n" + changes_note + "\n\n")
+                        esm_parser.user_error("YAML syntax",
+                                    "\The following ``_changes`` can be accessed " +
+                                    "simultaneously in " + fpath + ":\n" +
+                                    "    - " + ".".join(changes) + "\n" +
+                                    "    - " + ".".join(other_changes) + "\n" +
+                                    "\n" + changes_note + "\n\n")
 
             # Load the yaml file
             with open(fpath) as yaml_file:
@@ -178,7 +182,7 @@ def check_changes_duplicates(yamldict_all, fpath):
 def find_last_choose(var_path):
     """
     Locates the last ``choose_`` on a string containing the path to a
-    variable separated by ",", and returns the path to the ``choose_`` 
+    variable separated by ",", and returns the path to the ``choose_``
     (also separated by ",") and the case that follows the ``choose_``.
 
     Parameters

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -237,9 +237,8 @@ def check_duplicates(src):
             value = loader.construct_object(value_node, deep=deep)
 
             if key in mapping:
-                raise yaml.constructor.ConstructorError(
-                    "pping", node.start_mark,
-                    "\n\nKey ``{0}`` is duplicated {1}\n\n"
+                esm_parser.user_error("Duplicated variables",
+                    "Key ``{0}`` is duplicated {1}\n\n"
                     .format(key, str(key_node.start_mark).replace("  ","").split(",")[0]))
 
             mapping[key] = value

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -1,10 +1,219 @@
 import yaml
 import logging
+import esm_parser
 
 logger = logging.getLogger("root")
 DEBUG_MODE = logger.level == logging.DEBUG
 
 YAML_AUTO_EXTENSIONS = ["", ".yml", ".yaml", ".YML", ".YAML"]
+
+
+def yaml_file_to_dict(filepath):
+    """
+    Given a yaml file, returns a corresponding dictionary.
+
+    If you do not give an extension, tries again after appending one.
+    It raises an EsmConfigFileError exception if yaml files contain tabs.
+
+    Parameters
+    ----------
+    filepath : str
+        Where to get the YAML file from
+
+    Returns
+    -------
+    dict
+        A dictionary representation of the yaml file.
+
+    Raises
+    ------
+    EsmConfigFileError
+        Raised when YAML file contains tabs or other syntax issues.
+    FileNotFoundError
+        Raised when the YAML file cannot be found and all extensions have been tried.
+    """
+    for extension in YAML_AUTO_EXTENSIONS:
+        try:
+            with open(filepath + extension) as yaml_file:
+                # Check for duplicates
+                check_duplicates(yaml_file)
+                # Back to the beginning of the file
+                yaml_file.seek(0, 0)
+                # Actually load the file
+                yaml_load =  yaml.load(yaml_file, Loader=yaml.FullLoader)
+                # Check for incompatible ``_changes`` (no more than one ``_changes``
+                # type should be accessible simultaneously)
+                check_changes_duplicates(yaml_load, filepath + extension)
+                return yaml_load
+        except IOError as error:
+            logger.debug(
+                "IOError (%s) File not found with %s, trying another extension pattern.",
+                error.errno,
+                filepath + extension,
+            )
+        except yaml.scanner.ScannerError as yaml_error:
+            logger.debug("Your file %s has syntax issues!",
+                filepath + extension,
+            )
+            raise EsmConfigFileError(filepath + extension, yaml_error)
+    raise FileNotFoundError(
+        "All file extensions tried and none worked for %s" % filepath
+    )
+
+
+def check_changes_duplicates(yamldict_all, fpath):
+    """
+    Finds variables containing ``_changes`` (but excluding ``add_``) and checks
+    if they are compatible with the same ``_changes`` inside the same file. If they
+    are not compatible returns an error where the conflicting variable paths are
+    specified. More than one ``_changes`` type in a file are allowed but they need
+    to be part of the same ``_choose`` and not be accessible simultaneously in any
+    situation.
+
+    Parameters
+    ----------
+    yamldict_all : dict
+        Dictionary read from the yaml file
+    fpath : str
+        Path to the yaml file
+    """
+    changes_note = "Note that if there are more than one ``_changes`` in the " \
+                   "file, they need to be placed inside different cases of the " \
+                   "same ``choose`` and these options need to be compatible " \
+                   "(only one ``_changes`` can be reached at a time).\n" \
+                   "Use ``add_<variable>_changes`` if you want to add/overwrite " \
+                   "variables inside the main ``_changes``."
+    # If it is a couple setup, check for ``_changes`` duplicates separately for each component
+    if "general" not in yamldict_all:
+        yamldict_all = {"main": yamldict_all}
+    # Loop through the components or main
+    for yamldict in yamldict_all.values():
+        # Check if any <variable>_changes exist, if not, return
+        changes_list = esm_parser.find_key(yamldict, "_changes", "add_",
+                                           paths2finds = [], sep=",")
+        if len(changes_list) == 0:
+            return
+
+        # Find ``_changes`` types
+        changes_types = set([y for x in changes_list for y in x.split(",")
+                             if "_changes" in y])
+        # Define ``_changes`` groups
+        changes_groups = []
+        for change_type in changes_types:
+            changes_groups.append([x for x in changes_list if change_type == x.split(",")[-1]])
+
+        # Loop through the different groups
+        for changes_group in changes_groups:
+            # Check for ``_changes`` without ``choose_``, "there can be only one"
+            changes_no_choose = [x for x in changes_group if "choose_" not in x]
+            if len(changes_no_choose) > 1:
+                changes_no_choose = [x.replace(",",".") for x in changes_no_choose]
+                raise Exception("\n\nMore than one ``_changes`` out of a ``choose_``in "
+                                + fpath + ":\n    - " + "\n    - ".join(changes_no_choose) +
+                                "\n" + changes_note + "\n\n")
+            elif len(changes_no_choose) == 1:
+                changes_group.remove(changes_no_choose[0])
+                if len(changes_group) > 0:
+                    changes_group = [x.replace(",",".") for x in changes_group]
+                    raise Exception("\n\nThe general ``" + changes_no_choose[0] +
+                                    "`` and ``_changes`` in ``choose_`` are not compatible in "
+                                    + fpath + ":\n    - " +
+                                    "\n    - ".join(changes_group) + "\n" +
+                                    "\n" + changes_note + "\n\n")
+
+            # Check for incompatible ``_changes`` inside ``choose_``
+            changes_group_split = [x.split(",") for x in changes_group]
+            for count, changes in enumerate(changes_group_split):
+                path2choose, case = find_last_choose(changes)
+                for other_changes in changes_group_split[count+1:]:
+                    sub_path2choose, sub_case = find_last_choose(other_changes)
+                    if path2choose in sub_path2choose or sub_path2choose in path2choose:
+                        if case == sub_case:
+                            raise Exception("\n\nThe following ``_changes`` can be accessed " +
+                                         "simultaneously in " + fpath + ":\n" +
+                                         "    - " + ".".join(changes) + "\n" +
+                                         "    - " + ".".join(other_changes) + "\n" +
+                                         "\n" + changes_note + "\n\n")
+                    else:
+                        raise Exception ("\n\nThe following ``_changes`` can be accessed " +
+                                         "simultaneously in " + fpath + ":\n" +
+                                         "    - " + ".".join(changes) + "\n" +
+                                         "    - " + ".".join(other_changes) + "\n" +
+                                         "\n" + changes_note + "\n\n")
+
+            # Load the yaml file
+            with open(fpath) as yaml_file:
+                # Loop through the <variable>_changes found in the dictionary
+                for changes in changes_list:
+                    pass
+
+def find_last_choose(var_path):
+    """
+    Locates the last ``choose_`` on a string containing the path to a
+    variable separated by ",", and returns the path to the choose (also
+    separated by ",") and the case that follows the ``choose_``.
+
+    Parameters
+    ----------
+    var_path : str
+        String containing the path to the last ``choose_`` separated by
+        ",".
+    """
+    # Find the last ``choose_``
+    last_choose = [x for x in var_path if "choose_" in x][-1]
+    # Find the last ``choose_`` index
+    choose_index = var_path.index(last_choose)
+    # Defines the path to the last ``choose_``
+    path2choose = ",".join(var_path[:var_path.index(last_choose)+1])
+    # Defines the case of the last ``choose_``
+    case = var_path[choose_index+1]
+    return path2choose, case
+
+
+def check_duplicates(src):
+    """
+    Checks that there are no duplicates in a yaml file, and if there are
+    returns an error stating which key is repeated and in which file the
+    duplication occurs.
+
+    Parameters
+    ----------
+    src : object
+        Source file object
+
+    Exceptions
+    ----------
+    ConstructorError
+        If duplicated keys are found, returns an error
+    """
+
+    class PreserveDuplicatesLoader(yaml.loader.Loader):
+    # We eliberately define a fresh class inside the function,
+    # because add_constructor is a class method and we don't want to
+    # mutate pyyaml classes.
+        pass
+
+    def map_constructor(loader, node, deep=False):
+        """
+        Mapping, finds any duplicate keys.
+        """
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            value = loader.construct_object(value_node, deep=deep)
+
+            if key in mapping:
+                raise yaml.constructor.ConstructorError(
+                    "pping", node.start_mark,
+                    "\n\nKey ``{0}`` is duplicated {1}\n\n"
+                    .format(key, str(key_node.start_mark).replace("  ","").split(",")[0]))
+
+            mapping[key] = value
+
+        return loader.construct_mapping(node, deep)
+
+    PreserveDuplicatesLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, map_constructor)
+    return yaml.load(src, Loader=PreserveDuplicatesLoader)
 
 
 class EsmConfigFileError(Exception):
@@ -42,47 +251,3 @@ class EsmConfigFileError(Exception):
                            f"Your file {fpath} has tabs, please use ONLY spaces!\n" \
                             "Tabs are in following lines:\n" + report
         super().__init__(self.message)
-
-
-def yaml_file_to_dict(filepath):
-    """
-    Given a yaml file, returns a corresponding dictionary.
-
-    If you do not give an extension, tries again after appending one.
-    It raises an EsmConfigFileError exception if yaml files contain tabs.
-
-    Parameters
-    ----------
-    filepath : str
-        Where to get the YAML file from
-
-    Returns
-    -------
-    dict
-        A dictionary representation of the yaml file.
-
-    Raises
-    ------
-    EsmConfigFileError
-        Raised when YAML file contains tabs or other syntax issues.
-    FileNotFoundError
-        Raised when the YAML file cannot be found and all extensions have been tried.
-    """
-    for extension in YAML_AUTO_EXTENSIONS:
-        try:
-            with open(filepath + extension) as yaml_file:
-                return yaml.load(yaml_file, Loader=yaml.FullLoader)
-        except IOError as error:
-            logger.debug(
-                "IOError (%s) File not found with %s, trying another extension pattern.",
-                error.errno,
-                filepath + extension,
-            )
-        except yaml.scanner.ScannerError as yaml_error:
-            logger.debug("Your file %s has syntax issues!",
-                filepath + extension,
-            )
-            raise EsmConfigFileError(filepath + extension, yaml_error)
-    raise FileNotFoundError(
-        "All file extensions tried and none worked for %s" % filepath
-    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.1
+current_version = 4.2.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="4.2.1",
+    version="4.2.2",
     zip_safe=False,
 )


### PR DESCRIPTION
The issue was that if you have two `namelist_changes`  inside the same file, only the last one is chosen. That is partly the reason why we have the `add_namelist_changes` option, which adds modifications instead of completely overriding `namelist_changes`. In order to prevent errors as the `dt_start` (issue esm-tools/esm_tools#130) I added a functionality that checks for repetitions of  variables containing `_changes` (but excluding the ones with ``add_``) inside the same file (when same `_changes` are present in different files it works already as desired). After finding a repetition of `_changes` or incompatible `_changes` (same `_changes` that are in non-exclusive `choose_`)  it throws an error.

**Additionally this hotfix looks for duplicates inside yaml files** and returns an error if it finds some.

@seb-wahl, there are some duplicates in `oifs.yaml` found by executing:
```
esm_master
```

After your review, and if you agree with the changes, could you please fix the `oifs.yaml`?