### PR TITLE
Feature/file_load_traceback

### DIFF
--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -469,7 +469,34 @@ def dict_merge(dct, merge_dct):
             and isinstance(dct[k], dict)
             and isinstance(merge_dct[k], collections.Mapping)
         ):
-            dict_merge(dct[k], merge_dct[k])
+            # NOTE(PG): this is a very bad hack and doesn't belong here at all.
+            # Maybe instead the yaml_file_to_dict needs to say something like
+            # "add_debug_info", so everything gets put together, but for right
+            # now you are given ifnromation where your config originally came
+            # from...
+            #
+            # IDEA: It would be great if somehow we knew which key came from
+            # which config file: some are in the user, some are in the setup,
+            # some are in the component. However, I have no idea how to do that
+            # correctly...Turn the keys in the config into named tuples with
+            # the original file? Make a custom "class" for config keys?? That
+            # would then be:
+            #
+            # config['echam'].keys()
+            # * (key_name: namelist_changes, came_from: user, overrides: [setup, component])
+            # Above, the overrides list always gets longer depending on where the value actually came from.
+            # * (another key-tuple)
+            # * and so on...
+            #
+            # An idea...but I have absolutely no clue how to cleanly implement that...
+            if k is not "debug_info":
+                dict_merge(dct[k], merge_dct[k])
+            else:
+                if "debug_info" in dct:
+                    if isinstance(dct["debug_info"]["loaded_from_file"], str):
+                        dct["debug_info"]["loaded_from_file"] = [dct["debug_info"]["loaded_from_file"]]
+                    else:
+                        dct["debug_info"]["loaded_from_file"].append(merge_dct["debug_info"]["loaded_from_file"])
         else:
             dct[k] = merge_dct[k]
 

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -71,7 +71,9 @@ def yaml_file_to_dict(filepath):
     for extension in YAML_AUTO_EXTENSIONS:
         try:
             with open(filepath + extension) as yaml_file:
-                return yaml.load(yaml_file, Loader=yaml.FullLoader)
+                cfg = yaml.load(yaml_file, Loader=yaml.FullLoader)
+                cfg["debug_info"] = {"loaded_from_file": yaml_file.name}
+                return cfg
         except IOError as error:
             logger.debug(
                 "IOError (%s) File not found with %s, trying another extension pattern.",


### PR DESCRIPTION
# Summary:

Traceback info for where your yaml actually came from

# Example:
In your configuration, you get a new little part that tells you where the yaml file actually came from. Might be useful if you have `awiesm`, `awiesm-2.1`, and other versions. Apparently the one "with" the version always wins, but it took me a while to figure that out...

In the example, complete_config is something that is passed to EsmMaster:
```
pp complete_config['debug_info']                                                                                                                                                                                                                                                                                                                                    
{'loaded_from_file': '/mnt/lustre01/pf/a/a270077/Code/esm_tools/esm_tools/configs/setups/awiesm/awiesm-2.1.yaml'}
and:

pp complete_config['echam']['debug_info']                                                                                                                                                                                                                                                                                                                           
{'loaded_from_file': ['/mnt/lustre01/pf/a/a270077/Code/esm_tools/esm_tools/configs/components/echam/echam.yaml',
                      '/mnt/lustre01/pf/a/a270077/Code/esm_tools/esm_tools/configs/components/echam/echam.postprocessing.yaml']}
```

# Further Steps:

I had an idea that might be super useful, but I have no clue how to get it to work:

```
IDEA: It would be great if somehow we knew which key came from
which config file: some are in the user, some are in the setup,
 some are in the component. However, I have no idea how to do that
correctly...Turn the keys in the config into named tuples with
the original file? Make a custom "class" for config keys?? That
would then be:

config['echam'].keys()
* (key_name: namelist_changes, came_from: user, overrides: [setup, component])
Above, the overrides list always gets longer depending on where the value actually came from.
* (another key-tuple)
```
