### PR TITLE
removing duplicates fix

### DIFF
--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -848,9 +848,16 @@ def add_entry_to_chapter(
                 # Add the entries
                 mod_list += add_entries
                 # Remove duplicates
+                mod_list_no_dupl = []
+                for el in mod_list:
+                    if not isinstance(el, (dict, tuple, list)):
+                        if not el in mod_list_no_dupl:
+                            mod_list_no_dupl.append(el)
+                    else:
+                        mod_list_no_dupl.append(el)
                 target_config[model_to_add_to][
                     add_chapter.split(".")[-1].replace("add_", "")
-                ] = list(dict.fromkeys(mod_list))
+                ] = mod_list_no_dupl
                 global list_counter
                 list_counter += 1
             elif isinstance(


### PR DESCRIPTION
lines for removing duplicates in lists will make esm_master crash if the list contains a dictionary. Now dictionaries, tuples and lists are ignored for the duplicate check, and only the remaining clases are check for duplication