### PR TITLE
Hotfix converter underscore is no number

### DIFF
--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -2181,14 +2181,14 @@ def could_be_bool(value):
 def could_be_int(value):
     try:
         int(value)
-        return True
+        return contains_underscore(value)
     except:
         try:
             intval = int(
                 float(value)
             )  # that is actually necessary, because of int("48.0")
             if intval - float(value) == 0.0:
-                return True
+                return contains_underscore(value)
             else:
                 return False
         except:
@@ -2198,7 +2198,7 @@ def could_be_int(value):
 def could_be_float(value):
     try:
         float(value)
-        return True
+        return contains_underscore(value)
     except:
         return False
 
@@ -2206,9 +2206,16 @@ def could_be_float(value):
 def could_be_complex(value):
     try:
         complex(value)
-        return True
+        return contains_underscore(value)
     except:
         return False
+
+
+def contains_underscore(value):
+    if isinstance(value, str):
+        if "_" in value:
+            return False
+    return True
 
 
 def convert(value):


### PR DESCRIPTION
The `esm_parser.convert` method transforms strings into `int`, `float` or `complex`. The problem is that it can, for example, transform a string `"000_000"` into an `int` (`0`).

This is not desired for example in this situation for `oifs.yaml`:
```
end_filebase_wam: "${initial_date!syear!smonth!sday}000000_0000000000"
```

After evaluation, `end_filebase_wam` was turned into for example 1990101**0** instead of in 1990101**000000_0000000000**. `end_filebase_wam` is later used for paths, and therefore it should stay being a string and preserving the underscore.

This pull request solves the issue.