### PR TITLE
Fix/export env to sad

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.3"
+__version__ = "5.0.4"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -57,6 +57,7 @@ def create_env_loader(tag="!ENV", loader=yaml.SafeLoader):
     # the tag will be used to mark where to start searching for the pattern
     # e.g. somekey: !ENV somestring${MYENVVAR}blah blah blah
     loader.add_implicit_resolver(tag, pattern, None)
+    loader.env_variables = []
     def constructor_env_variables(loader, node):
         """
         Extracts the environment variable from the node's value
@@ -73,6 +74,7 @@ def create_env_loader(tag="!ENV", loader=yaml.SafeLoader):
                 full_value = full_value.replace(
                     f'${{{g}}}', os.environ.get(g, g)
                 )
+                load.env_variables.append((value, full_value))
             return full_value
         return value
 
@@ -120,6 +122,7 @@ def yaml_file_to_dict(filepath):
                 check_changes_duplicates(yaml_load, filepath + extension)
                 # Add the file name you loaded from to track it back:
                 yaml_load["debug_info"] = {"loaded_from_file": yaml_file.name}
+                print(loader.env_variables)
                 return yaml_load
         except IOError as error:
             logger.debug(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.3
+current_version = 5.0.4
 commit = True
 tag = True
 
@@ -18,4 +18,3 @@ universal = 1
 exclude = docs
 
 [aliases]
-

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.0.3",
+    version="5.0.4",
     zip_safe=False,
 )


### PR DESCRIPTION
While the extract env variable works nicely, it will break as soon as the job resubmits itself, since slurm doesn't inherit your shell.

Here, I grab all the extract environmental variables and add them to the the `add_export_vars` list, which are dumped into the sad file (Thanks @denizural for that idea!)

Can someone check if that makes sense, and merge it in as a patch with new numbers etc? Thanks!! :-)