### PR TITLE
feature/EsmToolsDir class

### DIFF
--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -110,15 +110,15 @@ DATE_MARKER = str(">>>THIS_IS_A_DATE<<<")
 import esm_rcfile
 
 
-FUNCTION_PATH = esm_rcfile.FUNCTION_PATH
+FUNCTION_PATH = esm_rcfile.EsmToolsDir("FUNCTION_PATH")
 SETUP_PATH = FUNCTION_PATH + "/setups"
 DEFAULTS_DIR = FUNCTION_PATH + "/defaults"
 COMPONENT_PATH = FUNCTION_PATH + "/components"
 
 
-esm_function_dir = esm_rcfile.FUNCTION_PATH
-esm_namelist_dir = esm_rcfile.get_rc_entry("NAMELIST_PATH", "NONE_YET")
-esm_runscript_dir = esm_rcfile.get_rc_entry("RUNSCRIPT_PATH", "NONE_YET")
+esm_function_dir = FUNCTION_PATH
+esm_namelist_dir = esm_rcfile.EsmToolsDir("NAMELIST_PATH")
+esm_runscript_dir = esm_rcfile.EsmToolsDir("RUNSCRIPT_PATH")
 
 gray_list = [
     r"choose_lresume",

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -163,13 +163,6 @@ def look_for_file(model, item):
             if os.path.isfile(possible_path + ending):
                 needs_loading = True
                 return possible_path + ending, needs_loading
-            if (possible_path + ending).startswith("NONE_YET"):
-                try:
-                    config = esm_tools.read_config_file(possible_path.replace("NONE_YET", "") + ending)
-                    needs_loading = False
-                    return config, needs_loading
-                except Exception as e:
-                    continue
     return None, None
 
 
@@ -1919,11 +1912,7 @@ def determine_computer_from_hostname():
     str
         A string for the path of the computer specific yaml file.
     """
-    # FIXME: This needs to be a resource file at some point
-    if FUNCTION_PATH.startswith("NONE_YET"):
-        all_computers = esm_tools.read_config_file("machines/all_machines.yaml")
-    else:
-        all_computers = yaml_file_to_dict(FUNCTION_PATH + "/machines/all_machines.yaml")
+    all_computers = yaml_file_to_dict(FUNCTION_PATH + "/machines/all_machines.yaml")
     for this_computer in all_computers:
         for computer_pattern in all_computers[this_computer].values():
             if isinstance(computer_pattern, str):
@@ -2474,23 +2463,15 @@ class ConfigSetup(GeneralConfig):  # pragma: no cover
             user_config["defaults"] = {}
 
         default_infos = {}
-        if not DEFAULTS_DIR.startswith("NONE_YET"):
-            for i in os.listdir(DEFAULTS_DIR):
-                file_contents = yaml_file_to_dict(DEFAULTS_DIR + "/" + i)
-                default_infos.update(file_contents)
-        else:
-            for i in esm_tools.list_config_dir(DEFAULTS_DIR.replace("NONE_YET/", "")):
-                file_contents = esm_tools.read_config_file(DEFAULTS_DIR.replace("NONE_YET/", "")+"/"+i)
-                default_infos.update(file_contents)
+        for i in os.listdir(DEFAULTS_DIR):
+            file_contents = yaml_file_to_dict(DEFAULTS_DIR + "/" + i)
+            default_infos.update(file_contents)
 
 
         user_config["defaults"].update(default_infos)
 
         computer_file = determine_computer_from_hostname()
-        if computer_file.startswith("NONE_YET"):
-            computer_config = esm_tools.read_config_file(computer_file.replace("NONE_YET/", ""))
-        else:
-            computer_config = yaml_file_to_dict(computer_file)
+        computer_config = yaml_file_to_dict(computer_file)
         setup_config = {
             "computer": computer_config,
             "general": {},


### PR DESCRIPTION
**Note**: not be reviewed yet (review only when the TODO list is checked out :) )

Puts esm-tools/esm_rcfile#2 into use:

Now, the variables `${esm_configs_dir}`, `${esm_runscripts_dir}` and `${esm_namelist_dir}` are an EsmToolsDir instance that "waits" until they are called by another variable (i.e. `method: ${esm_configs_dir}/path_to_your_preprocessing_script`) to find the adequate path depending if the run is open or occurs inside a virtual environment.

**Requires**
- esm-tools/esm_rcfile#2
- esm-tools/esm_tools#279

**TODO**
- [x] Testing with `oifs` preprocessing for an open run
- [x] Testing with `oifs` preprocessing for a run with venv
- [x] Remove the unnecessary `NONE_YET` blocks in all the packages
- [x] AWICM3 test
- [x] AWICM1 test