### PR TITLE
bugfix for using env tag inside the yaml file

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.4"
+__version__ = "5.0.5"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -93,13 +93,15 @@ def create_env_loader(tag="!ENV", loader=yaml.SafeLoader):
         # read the file into a list of line. This can also be achieved by 
         # read() instead but since the YAML files are not large (max few KBs),
         # this is a quicked solution
-        file_lines = open(fname, 'r').readlines()
+        yaml_file = open(fname, 'r')
+        file_lines = yaml_file.readlines()
+        yaml_file.close()
         
         # current line without the newline at the end 
         cur_line = file_lines[line_num].rstrip()
         
         # Print extra debug messages if ESM_PARSER_DEBUG environment variable is set
-        if os.environ.get("ESM_PARSER_DEBUG", None):
+        if os.getenv("ESM_PARSER_DEBUG"):
             print()
             print("===== esm_parser -> yaml_to_dict.py -> create_env_loader() =====")
             print(f"::: Reading the file: {fname}")
@@ -125,8 +127,9 @@ def create_env_loader(tag="!ENV", loader=yaml.SafeLoader):
 
                     # first check if the variable exists in the shell environment
                     if not os.getenv(env_var): 
-                        print(f"!!! ERROR: {env_var} is not an environment variable. Exiting")
-                        sys.exit(1)
+                        esm_parser.user_error(f"{env_var} is not defined",
+                            f"{env_var} is not an environment variable. Exiting"
+                        )
                         
                     # replace {env_var} with the value of the env_var
                     full_value = full_value.replace(

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -51,12 +51,25 @@ class EsmConfigFileError(Exception):
 
 # This next part is stolen here:
 # https://medium.com/swlh/python-yaml-configuration-with-environment-variables-parsing-77930f4273ac
+# Deniz: unfortunately this example as well as the other examples and even 
+# PyYaml itself is bit buggy. Basically everything with ${VAR} passes through 
+# the pipeline and this ends up replacing anything with ${VAR} with VAR and 
+# export them as environmental variables. That propagates even further and 
+# messes up the rest of the esm_tools (eg. master, runscripts, ...). The fix 
+# below corrects that issue.
 def create_env_loader(tag="!ENV", loader=yaml.SafeLoader):
-    # pattern for global vars: look for ${word}
-    pattern = re.compile('\${(\w+)}')
+    # pattern for ${VAR} and extract VAR 
+    pattern_envvar = re.compile('\${(\w+)}')
+    
+    # This pattern matches the valid (uncommented) !ENV lines. Eg.
+    # - !ENV ${VAR}
+    # - !ENV "${VAR}" or !ENV '${VAR}'
+    # Note: '!ENV ...' or "!ENV ..." does not work since PyYaml requires the tag outside of the quotes
+    pattern_envtag = re.compile("""^[^\#]*\!ENV[ \t]+['|"]?\$\{\w+\}['|"]?""")
+
     # the tag will be used to mark where to start searching for the pattern
     # e.g. somekey: !ENV somestring${MYENVVAR}blah blah blah
-    loader.add_implicit_resolver(tag, pattern, None)
+    loader.add_implicit_resolver(tag, pattern_envvar, None)
     loader.env_variables = []
     def constructor_env_variables(loader, node):
         """
@@ -66,16 +79,61 @@ def create_env_loader(tag="!ENV", loader=yaml.SafeLoader):
         :return: the parsed string that contains the value of the environment
         variable
         """
+        # file name (including the full path if not in PWD)
+        fname = node.start_mark.name
+
+        # line number (starts from 0) where match is found
+        line_num = node.start_mark.line
+
+        # start and end of the colums numbers in the line (starts from 0)
+        # For character index from the start of the file use node.start_mark.index
+        column_start = node.start_mark.column
+        column_end = node.end_mark.column
+        
+        # read the file into a list of line. This can also be achieved by 
+        # read() instead but since the YAML files are not large (max few KBs),
+        # this is a quicked solution
+        file_lines = open(fname, 'r').readlines()
+        
+        # current line without the newline at the end 
+        cur_line = file_lines[line_num].rstrip()
+        
+        # Print extra debug messages if ESM_PARSER_DEBUG environment variable is set
+        if os.environ.get("ESM_PARSER_DEBUG", None):
+            print()
+            print("===== esm_parser -> yaml_to_dict.py -> create_env_loader() =====")
+            print(f"::: Reading the file: {fname}")
+            print("::: Reading the line:")
+            print(f">>>{cur_line}<<<")
+            print(f"::: found the match: >>>{cur_line[column_start:column_end]}<<<")
+            print("==================== END OF ESM_PARSER_DEBUG ===================")
+            print()
+        
         value = loader.construct_scalar(node)
-        match = pattern.findall(value)  # to find all env variables in line
-        if match:
-            full_value = value
-            for g in match:
-                full_value = full_value.replace(
-                    f'${{{g}}}', os.environ.get(g, g)
-                )
-                loader.env_variables.append((g, full_value))
-            return full_value
+        
+        # Check if we have a valid !ENV tag on the line
+        envtag_match = re.search(pattern_envtag, cur_line)
+        
+        # list of matches for ${VAR}. Each match is VAR
+        envvar_matches = pattern_envvar.findall(value) 
+
+        # Parse the environmental variables only if the line has a valid !ENV tag
+        if envtag_match:
+            if envvar_matches: 
+                full_value = value
+                for env_var in envvar_matches:
+
+                    # first check if the variable exists in the shell environment
+                    if not os.getenv(env_var): 
+                        print(f"!!! ERROR: {env_var} is not an environment variable. Exiting")
+                        sys.exit(1)
+                        
+                    # replace {env_var} with the value of the env_var
+                    full_value = full_value.replace(
+                        f'${{{env_var}}}', os.getenv(env_var)
+                    )
+                    loader.env_variables.append((env_var, full_value))
+                return full_value
         return value
 
     loader.add_constructor(tag, constructor_env_variables)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.4
+current_version = 5.0.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.0.4",
+    version="5.0.5",
     zip_safe=False,
 )


### PR DESCRIPTION
This bugfix fixes the issues reported by @seb-wahl and @koldunovn.

This is actually an issue in PyYaml and all code samples regarding to using environmental variable inside YAML files (eg. on stackoverflow or the code that Paul inherited).

What happens is `add_implicit_resolver` takes everything inside and replaces any `${VAR}` with the string value or `VAR`. This further propogates by changing esm_tools variables like `${pseudo_date}` to `pseudo_date` and then `mark_date` function makes them a date variable and tries to parse them as a date variable. 

Look at this example:
```
Inside marked_date_to_date_object. entry: start_date>>>THIS_IS_A_DATE<<<
ndate: ['s', 'ta', 'rt', 'da', 'te', '00']
```
Here `start_date` variable used to be `${start_date}` somewhere earlier. 

PS: since I have a dentist appointment now. Could you please check it with your cases. 
I controlled it with `esm_master get-foci-default --verbose -c &>output` that used to fail for @seb-wahl 
For further debug notices you can set
`export ESM_PARSER_DEBUG=1`