### PR TITLE
Hotfix/asterisk in choose blocks

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.5"
+__version__ = "5.0.6"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -579,6 +579,15 @@ def deep_update(chapter, entries, config, blackdict={}):
      else:
         if chapter not in blackdict:
             dict_merge(config, {chapter: entries})
+        # deniz: bugfix: choose_ blocks with "*" keys don't get updated. Eg. 
+        # mail1 and mail2 don't get updated since they are initialized as empty
+        # strings and are already inside. Current bug fix only correct scalar
+        # types such as strings.  
+        else:
+            empty_values = ["", None]
+            if blackdict[chapter] in empty_values and entries not in empty_values:
+                dict_merge(config, {chapter: entries})
+                
 
 
 def find_remove_entries_in_config(mapping, model_name, models = []):

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -579,13 +579,23 @@ def deep_update(chapter, entries, config, blackdict={}):
      else:
         if chapter not in blackdict:
             dict_merge(config, {chapter: entries})
+     
         # deniz: bugfix: choose_ blocks with "*" keys don't get updated. Eg. 
         # mail1 and mail2 don't get updated since they are initialized as empty
         # strings and are already inside. Current bug fix only correct scalar
         # types such as strings.  
         else:
-            empty_values = ["", None]
-            if blackdict[chapter] in empty_values and entries not in empty_values:
+            empty_values = ["", None]  # some possible empty values to override
+
+            # strip all whitespace. Eg. "  " -> "", if it is only space
+            if (isinstance(blackdict[chapter], str) and 
+                blackdict[chapter].isspace()):
+                blackdict[chapter] = re.sub(r"\s+", "", blackdict[chapter])
+
+            # The update_key (chapter) is already inside the blackdict however,
+            # its value (entries) it not empty. So, update them 
+            if (blackdict[chapter] in empty_values and entries not in 
+                empty_values):
                 dict_merge(config, {chapter: entries})
                 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.5
+current_version = 5.0.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.0.5",
+    version="5.0.6",
     zip_safe=False,
 )


### PR DESCRIPTION
I discovered this bug while implementing a new slurm feature into esm-tools (I will make that pull request later). I realized that the flag that I am passing never gets into the sad file although the dump of the config shows that it is defined. I noticed that when we have a construct such as

```yaml
choose_mail_type:
    "*":
        mail1:  "--mail-type=${mail_type}"
```
`resolve_basic_choose` calls the `deep_update`, but there are some variables that are initialized as None or empty strings and could be updated from another yaml file. For example, try to send the user a Slurm e-mail as described in

https://esm-tools.readthedocs.io/en/latest/recipes/sbatch_flags.html?highlight=mail_type#change-add-flags-to-the-sbatch-call

this does not work because even though `mail_type` and `mail_user` that are set by the user (eg. in runscript) enter the `config`, they don't enter `mail1`, `mail2` and therefore `notification_flag` that `slurm.py` processes. 

You can check if this bugfix is working by 
adding 
```yaml
mail_type: FAIL
mail_user: "fizzbuzz@foobar.com"
```
and then 
`esm_runscript <your-favourite-runscript> --check --verbose --open-run -e test &> output.log`

Just `vimdiff` the logs and you should see that in the bugfix branch you should see
`#SBATCH --mail-type=FAIL --mail-user=fizzbuzz@foobar.com` but in the release branch they should be missing. 

Note that this bugfix is not only for the mail types but any variable inside the `choose_` blocks that contain `"*"` option.

**PS:** in the second commit, I added some more conservative checks. Eg. what if the variable is initialized as 
`user_mail: " "` instead of `user_mail: ""`. That single space (or tab, ...) could break it without the next fix.