### PR TITLE
added a new function: get_value_in_nested_dict

### DIFF
--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -2388,6 +2388,43 @@ def find_key(d_search, k_search, exc_strings = "", level = "", paths2finds = [],
     return paths2finds
 
 
+def get_value_in_nested_dict(container, search_key):
+    """Checks for the ``search_key`` inside the (nested) dictionary ``container``
+    and returns the generator object of values of that key.
+    
+    Parameters
+    ----------
+    container : dict
+        dictionary to search for
+    search_key : any "hashable" Python object, eg. str, int
+    
+    Yields
+    ------
+    result : generator object 
+        value(s) of the key ``search_key`` in the dictionary
+    """
+    
+    # case 1: the container to search in is a dictionary
+    if isinstance(container, dict):
+        # what we are looking for is already a key in the dictionary, yield 
+        # it's value
+        if search_key in container:
+            yield container[search_key]
+        
+        # or it might be inside its values. For each value search recursively
+        for value in container.values():
+            for result in get_value_in_nested_dict(value, search_key):
+                yield result
+                
+    # case 2: the node of the nested dictionary is a list. Recursively search
+    # its items
+    elif isinstance(container, list):
+        for item in container:
+            for result in get_value_in_nested_dict(item, search_key):
+                yield result
+
+
+
 def user_note(note_heading, note_text):
     """
     Notify the user about something. In the future this should also write in the log.


### PR DESCRIPTION
I added this functionality to get the list of values from a dictionary for a given key. There is already a function called `find_key` but it does not do what I want it to do and even more, I think there a some odd behaviour in that function. Look at this test:

```Python
from esm_parser import find_key
from esm_parser import get_value_in_nested_dict
import yaml

# esm_tools/configs/machines/generic.yaml
with open('generic.yaml') as f:    
    data = yaml.load(f, Loader=yaml.FullLoader)
      
    mykey = "fc"

    search_list = find_key(data, [mykey], exc_strings = "", level = "", paths2finds = [], sep = ".")
    print("Result of find_key:")
    print(search_list)
        
    search_list_2 = get_value_in_nested_dict(data, mykey)
    print("Result of get_value_in_nested_dict:")
    print(list(search_list_2))
```
then the result is 

```
Result of find_key:
['choose_useMPI.intelmpi.fc', 'choose_useMPI.intelmpi.mpifc', 'choose_useMPI.openmpi.fc', 'choose_useMPI.openmpi.mpifc']

Result of get_value_in_nested_dict:
['mpiifort', 'mpif90']
```

The previous function (`find_key`) even matches mpifc. Is this the expected behaviour? I think the `in` operator is causing the trouble here. I think `==` operator should be use to compare the strings. 

In any case I think this new function will be useful for the future cases.