### PR TITLE
fix/look for file

### DIFF
--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -188,7 +188,7 @@ def look_for_file(model, item):
                 needs_loading = True
                 return possible_path + ending, needs_loading
 
-    # If the item is a subversion of a model version with it's own file (e.g.
+    # If the item is a subversion of a model version with its own file (e.g.
     # item = fesom-2.0-jio and model = fesom), the previous lines won't be able
     # to find the versioned file (e.g. fesom-2.0.yaml) cause it is looking for
     # a file which name contains the whole item string (e.g. fesom-2.0-jio.yaml).

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -201,7 +201,8 @@ def look_for_file(model, item):
             return possible_path, needs_loading
 
     # The file was not found
-    return None, None
+    warnings.warn(f'File for "{item}" not found in "{model}"')
+    return None, False
 
 
 def shell_file_to_dict(filepath):

--- a/esm_parser/yaml_to_dict.py
+++ b/esm_parser/yaml_to_dict.py
@@ -370,9 +370,21 @@ def check_changes_duplicates(yamldict_all, fpath):
         for add_group in add_groups:
             # Count ``add_`` occurrences out of a ``choose_``
             add_no_choose = [x for x in add_group if "choose_" not in x]
+            # Check if the heading of the path is the same. If not is not a
+            # repetition
+            for anc in add_no_choose:
+                add_no_choose = []
+                heading = anc.split(",")[0]
+                counter = 0
+                for ag in add_group:
+                    if heading in ag:
+                        counter += 1
+                if counter > 1:
+                    add_no_choose.append(anc)
+
             # If one ``add_`` without ``choose_`` check for ``add_`` inside
             # ``choose_`` and return error if any is found (incompatible ``add_``s)
-            if len(add_no_choose) == 1:
+            if len(add_no_choose) >= 1:
                 add_group.remove(add_no_choose[0])
                 if len(add_group) > 0:
                     add_group = [x.replace(",", ".") for x in add_group]


### PR DESCRIPTION
This fix solves the following issue:

When using `esm_master` to compile a subversion of FESOM2, `fesom-2.0-jio`,  `look_for_file` method ends up with `model = 'fesom'` and `item = 'fesom-2.0-jio'` in the following lines:
https://github.com/esm-tools/esm_parser/blob/develop/esm_parser/esm_parser.py#L349-L351

In this case, `look_for_file` was not able to find the correct config file since it was looking for `fesom-2.0-jio.yaml` instead of for `fesom-2.0.yaml`. This would mean that line 351 would be reached, loading `fesom.yaml` (not the right file for FESOM2). This was unimportant up to this point because this was only happening for `esm_master` (in `esm_runscripts` the issue was avoided by defining `fesom.version: 2.0` in the yamls), and because `fesom-2.0.yaml` and `fesom.yaml` only included unimportant testing `compiletime_environment_changes` export variables, however, this could be a source of compilation errors in other models with different configuration files for different versions.