### PR TITLE
choose blocks can now evaluate variables containing math operations

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.6"
+__version__ = "5.0.7"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -1254,6 +1254,8 @@ def resolve_basic_choose(config, config_to_replace_in, choose_key, blackdict={})
             #del config_to_replace_in[choose_key]
             gray_list.append(re.compile(choose_key))
             return
+    if isinstance(choice, str) and "$((" in choice:
+        choice = do_math_in_entry([False], choice, config)
     logging.debug(choice)
 
     if choice in config_to_replace_in.get(choose_key):

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -1254,6 +1254,7 @@ def resolve_basic_choose(config, config_to_replace_in, choose_key, blackdict={})
             #del config_to_replace_in[choose_key]
             gray_list.append(re.compile(choose_key))
             return
+    # Evaluates the mathematical expressions in the choose_ blocks
     if isinstance(choice, str) and "$((" in choice:
         choice = do_math_in_entry([False], choice, config)
     logging.debug(choice)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.6
+current_version = 5.0.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.0.6",
+    version="5.0.7",
     zip_safe=False,
 )


### PR DESCRIPTION
Before, choose blocks where the choice value was a math expression, were not working correctly, because the math expression was not evaluated when the choose was reached.

For example the following definition in a yaml file:
```
number: 3
larger_than_two: "$(( ${number} > 2 ))"
choose_larger_than_two:
    true:
        whatever_is_needed: here 
    "*": 
        it_did_not_work: ${larger_than_two}
```

will result in a `it_did_not_work: true` variable, instead of `whatever_is_needed: here`. Now it works correctly.