### PR TITLE
Hotfix/forcing sources

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.7"
+__version__ = "5.0.8"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -2723,8 +2723,13 @@ class ConfigSetup(GeneralConfig):  # pragma: no cover
         if not "coupled_setup" in self.config["general"]:
             self._blackdict = blackdict = user_config
 
-        pdb.set_trace()                                                                                                # deniz:
         
+        # deniz: if the user-defined forcing_sources (inside the runscript) is
+        # a dictionary with multiple levels then the users need to provide
+        # 'overwrite' key at the level that they want to change. Otherwise,
+        # the parser basically appends that to the forcing_sources and since
+        # Python dictionaries are unordered noone can guarantee which source is
+        # taken
         self.config = dict_overwrite(sender=user_config, receiver=self.config, 
             key_path=[], verbose=self.config['general']['verbose'])
         

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.7
+current_version = 5.0.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.0.7",
+    version="5.0.8",
     zip_safe=False,
 )


### PR DESCRIPTION
## Problem:
As we have in the documentation (https://esm-tools.readthedocs.io/en/latest/cookbook.html#include-a-new-forcing-input-file), it is possible for the users to override the `forcing_sources` in the runscripts. However, there is a very big issue there. 

When the user tries to update a simple forcing file, eg.
```yaml
forcing_sources:
    '1850ozone': '${foo}/ozone/${bar}_ozone_historical_1850.nc'
```
That is fine since, this is a simple `key:value` pair. However, if you do this:
```yaml
forcing_sources:
    '1850ozone': '${foo}/ozone/${bar}_ozone_historical_1850.nc'
    "histozone":
        ${foo}/ozone/${bar}_ozone_historical_1850.nc:
            to: 1850
        ${fizz}/ozone/${buzz}_ozone_historical_@YEAR@.nc:
            from: 1851
            to: 2008
```
This will simply add the information given for `histozone` to whatever there is as a default file. This is extremely erroneous since Python does not guarantee the order of the items in a dictionary (unless you use `OrderedDict` from the `collections` module). Even if the files are inserted to the start of the list the unwanted sources will still be there. This means that they are **not** overwritten. 
**PS:** As I see in the parser code Paul also complains about the order of how config are read. He made another bug there btw that I will solve later on. 

## Solution: 
The users need to provide an additional `overwrite: True` under the block where they want to change. Eg.
```yaml
echam:
    forcing_sources:
        '1850ozone': '${foo}/ozone/${bar}_ozone_historical_1850.nc'     # this is fine
        "histozone":
            overwrite: True                                                                          # add this overwrite histozone
            ${foo}/ozone/${bar}_ozone_historical_1850.nc:
                to: 1850
            ${fizz}/ozone/${buzz}_ozone_historical_@YEAR@.nc:
                from: 1851
                to: 2008
...
jsbach:
    forcing_sources:
        "LU_HIST":
            overwrite: true                                                                          # also here
            "/pool/data/JSBACH/input/r0006/T127/New_Hampshire_LCC/hist/LUH_harvest_T127_1850.nc":
                to: 1850
            "/pool/data/JSBACH/input/r0006/T127/New_Hampshire_LCC/hist/LUH_harvest_T127_@YEAR@.nc":
                from: 1851
```

If the `verbose` is on, then it will print:

```
::: Overwriting the path:    [echam -> forcing_sources -> histozone]
::: value before:
    ${fizz}/ozone/${buzz}_ozone_historical_@YEAR@.nc:
        from: 1851
        to: 2008
    ${foo}/ozone/${bar}_ozone_historical_1850.nc:
        to: 1850
    ${forcing_dir}/ozone/${resolution}_ozone_historical_1850.nc:
        to: 1850
    ${forcing_dir}/ozone/${resolution}_ozone_historical_@YEAR@.nc:
        from: 1851
        to: 2008
    overwrite: true
---
::: value after:
    ${fizz}/ozone/${buzz}_ozone_historical_@YEAR@.nc:
        from: 1851
        to: 2008
    ${foo}/ozone/${bar}_ozone_historical_1850.nc:
        to: 1850

::: Overwriting the path:    [jsbach -> forcing_sources -> LU_HIST]
::: value before:
    ${input_dir}/${echam.resolution}/New_Hampshire_LCC/${hist_fold}/LUH_harvest_${echam.resolution}_1850.nc:
        to: 1850
    ${input_dir}/${echam.resolution}/New_Hampshire_LCC/${hist_fold}/LUH_harvest_${echam.resolution}_@YEAR@.nc:
        from: 1851
    /pool/data/JSBACH/input/r0006/T127/New_Hampshire_LCC/hist/LUH_harvest_T127_1850.nc:
        to: 1850
    /pool/data/JSBACH/input/r0006/T127/New_Hampshire_LCC/hist/LUH_harvest_T127_@YEAR@.nc:
        from: 1851
    overwrite: true
---
::: value after:
    /pool/data/JSBACH/input/r0006/T127/New_Hampshire_LCC/hist/LUH_harvest_T127_1850.nc:
        to: 1850
    /pool/data/JSBACH/input/r0006/T127/New_Hampshire_LCC/hist/LUH_harvest_T127_@YEAR@.nc:
        from: 1851
```