### PR TITLE
hotfix/include models in general choose

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.0"
+__version__ = "5.1.1"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.1"
+__version__ = "5.1.2"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -292,8 +292,11 @@ def pprint_config(config):  # pragma: no cover
     -------
     None
     """
+    config_to_print = copy.deepcopy(config) #PrevRunInfo
+    if "prev_run" in config_to_print:       #PrevRunInfo
+        del config_to_print["prev_run"]     #PrevRunInfo
     yaml.Dumper.ignore_aliases = lambda *args: True
-    print(yaml.dump(config, default_flow_style=False))
+    print(yaml.dump(config_to_print, default_flow_style=False))
 
 
 def attach_to_config_and_reduce_keyword(
@@ -1676,8 +1679,8 @@ def recursive_run_function(tree, right, level, func, *args, **kwargs):
         for key in keys:
             # Avoid doing this for ``prev_run`` chapters, this is not needed as the
             # previous config is already resolved
-            if key == "prev_run":
-                continue
+            if key == "prev_run": #PrevRunInfo
+                continue          #PrevRunInfo
             value = right[key]
             right[key] = recursive_run_function(
                 tree + [key], value, level, func, *args, **kwargs

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -2624,6 +2624,13 @@ class ConfigSetup(GeneralConfig):  # pragma: no cover
 
         if "general" in self.config and "coupled_setup" in self.config["general"]:
             setup_config["general"].update({"standalone": False})
+            # Resolve choose with include_models
+            resolve_choose_with_var(
+                "include_models",
+                self.config["general"],
+                user_config=user_config,
+                setup_config=setup_config,
+            )
             setup_config["general"]["include_models"] = self.config["general"][
                 "include_models"
             ]
@@ -2645,7 +2652,7 @@ class ConfigSetup(GeneralConfig):  # pragma: no cover
             setup_config["general"].update({"standalone": True})
             setup_config["general"].update({"models": [self.config["model"]]})
 
-            # Resolve choose with include_models (Miguel)
+            # Resolve choose with include_models
             resolve_choose_with_var(
                 "include_models",
                 self.config,

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -292,6 +292,8 @@ def pprint_config(config):  # pragma: no cover
     -------
     None
     """
+    # Delete the ``prev_run`` chapter: we don't need to print the info from the
+    # previous run.
     config_to_print = copy.deepcopy(config) #PrevRunInfo
     if "prev_run" in config_to_print:       #PrevRunInfo
         del config_to_print["prev_run"]     #PrevRunInfo

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.1
+current_version = 5.1.2
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.0
+current_version = 5.1.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.0",
+    version="5.1.1",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.1",
+    version="5.1.2",
     zip_safe=False,
 )


### PR DESCRIPTION
`include_models` is a special list that takes care of including the information of the necessary component files into the `config`. In order to put all the information together, this variable needs to be used pretty early in the `esm_parser`, also earlier than the solution of the `choose_` blocks. That means `choose_` blocks containing `include_models` need to be resolved right before using `include_models` to load the component configurations.

This was a problem on the past for `oifs` trying to include `xios` through a `choose_`. This was solved for the standalone components such as `oifs`, but not for a `choose_` that contains `include_models` variables in the `general` section (i.e. in `awiesm-2.1` we want to add `recom` to `include_models` when the version `2.1-recom` is specified). This hotfix solves this problem so that awiesm-2.1-recom works as expected when `awiesm.version: 2.1-recom`:

**awiesm-2.1.yaml**

```
        choose_version:
          [ ... ]
          '2.1-recom':
            add_include_models:
            - recom
```