### PR TITLE
hotfix/remove_in_choose_block

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.2"
+__version__ = "5.1.3"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -603,12 +603,7 @@ def dict_merge(dct, merge_dct):
 
 
 def deep_update(chapter, entries, config, blackdict={}):
-     if "remove_" in chapter:
-        remove_chapter = chapter.replace("remove_", "")
-        remove_entries_from_chapter(config, remove_chapter, entries)
-        #del config[chapter]
-
-     elif "add_" in chapter:
+     if "add_" in chapter:
         add_chapter = chapter.replace("add_", "")
         add_entries_from_chapter(config, add_chapter, entries)
         #del config[chapter]
@@ -784,7 +779,7 @@ def remove_entry_from_chapter(
     """
 
     logging.debug("%s, %s", remove_entries, remove_chapter)
-    # Check that the the user entry is a least, if not rise an exception
+    # Check that the the user entry is a list, if not rise an exception
     if not isinstance(remove_entries, list):
         raise TypeError("Please put all entries to remove as a list")
     # Check for ``namelist_changes`` and change the extension dot ``.`` for a ``,``

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.2
+current_version = 5.1.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.2",
+    version="5.1.3",
     zip_safe=False,
 )


### PR DESCRIPTION
The `remove_` commands where handled by `deep_update` when contained in a `choose_` block. The function used there for `remove` (`remove_entries_from_chapter`) could not resolve removes of nested variables (i.e. `remove_namelist_changes.namelist.config: [inout]`). The more general resolution of `remove_` variables happens anyway afterwards at the end of `choose_blocks` method:
https://github.com/esm-tools/esm_parser/blob/e8afd6156ad1b23ae80ddeaf052f763f69b27f0a/esm_parser/esm_parser.py#L2427

So I removed the `remove` functionality from `deep_update` as a better resolution of `remove_` commands happens later anyway.