### PR TITLE
Hotfix/further reading

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.3"
+__version__ = "5.1.4"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -168,24 +168,31 @@ def look_for_file(model, item):
     """
 
     # Loop through all possible path combinations
-    for possible_path in [
-            SETUP_PATH + "/" + model + "/" + item  ,
-            COMPONENT_PATH + "/" + model + "/" + item ,
-            FUNCTION_PATH + "/esm_software/" + model + "/" + item,
-            FUNCTION_PATH + "/other_software/" + model + "/" + item,
-            FUNCTION_PATH + "/" + model + "/" + item ,
-            ]:
+    possible_paths = [ f"{SETUP_PATH}/{model}/{item}",                                                                 # deniz: this is better
+        f"{COMPONENT_PATH}/{model}/{item}",
+        f"{FUNCTION_PATH}/esm_software/{model}/{item}",
+        f"{FUNCTION_PATH}/other_software/{model}/{item}",
+        f"{FUNCTION_PATH}/{model}/{item}",
+        # f"{os.getcwd()}/{item}"                                                                                        # deniz: added this
+    ]
+
+    endings = [ "", ".yaml", ".yml", ".YAML", ".YML" ]                                                             # deniz: this is better
+    
+    # import pdb; pdb.set_trace()                                                                                        # deniz:
+
+    for possible_path in possible_paths:
+        
         # Loop through all possible formats
-        for ending in [
-                "",
-                ".yaml",
-                ".yml",
-                ".YAML",
-                ".YML",
-                ]:
+        for ending in endings:
+
+            # first strip off  any file extensions and add the current one                                             # deniz:
+            # possible_path = os.path.splitext(possible_path)[0]
+            # possible_path += ending
+
             # Check if the file exists and if it does return its path
-            if os.path.isfile(possible_path + ending):
+            if os.path.isfile(possible_path):
                 needs_loading = True
+                # return possible_path, needs_loading                                                                  # deniz:
                 return possible_path + ending, needs_loading
 
     # If the item is a subversion of a model version with its own file (e.g.

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -168,32 +168,27 @@ def look_for_file(model, item):
     """
 
     # Loop through all possible path combinations
-    possible_paths = [ f"{SETUP_PATH}/{model}/{item}",                                                                 # deniz: this is better
+    possible_paths = [ f"{SETUP_PATH}/{model}/{item}",
         f"{COMPONENT_PATH}/{model}/{item}",
         f"{FUNCTION_PATH}/esm_software/{model}/{item}",
         f"{FUNCTION_PATH}/other_software/{model}/{item}",
         f"{FUNCTION_PATH}/{model}/{item}",
-        # f"{os.getcwd()}/{item}"                                                                                        # deniz: added this
+        f"{os.getcwd()}/{item}"
     ]
 
-    endings = [ "", ".yaml", ".yml", ".YAML", ".YML" ]                                                             # deniz: this is better
+    endings = [ "", ".yaml", ".yml", ".YAML", ".YML" ]
     
-    # import pdb; pdb.set_trace()                                                                                        # deniz:
-
     for possible_path in possible_paths:
-        
-        # Loop through all possible formats
-        for ending in endings:
+        # first strip off any file extensions and add the current one
+        root_name = os.path.splitext(possible_path)[0]
 
-            # first strip off  any file extensions and add the current one                                             # deniz:
-            # possible_path = os.path.splitext(possible_path)[0]
-            # possible_path += ending
+        for ending in endings:
+            file_path = root_name + ending
 
             # Check if the file exists and if it does return its path
-            if os.path.isfile(possible_path):
+            if os.path.isfile(file_path):
                 needs_loading = True
-                # return possible_path, needs_loading                                                                  # deniz:
-                return possible_path + ending, needs_loading
+                return file_path, needs_loading
 
     # If the item is a subversion of a model version with its own file (e.g.
     # item = fesom-2.0-jio and model = fesom), the previous lines won't be able

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.3
+current_version = 5.1.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.3",
+    version="5.1.4",
     zip_safe=False,
 )


### PR DESCRIPTION
This hotfix solves the issue of not finding the `further_reading` section in the Yaml runscripts. Before the fix, I (and some other colleagues) receive
```
/mnt/lustre01/pf/a/a271096/esm_all_packages/esm_parser/esm_parser/esm_parser.py:211: UserWarning: File for "fesom_output_control.yaml" not found in "."
```
when I have something like
```yaml 
fesom:
    further_reading: "fesom_output_control.yaml"
```
in my runscript.

This bug fix first removes the file extension and then adds the supported ones back to check if they exist. This is necessary to prevent having things like `fesom_output_control.yaml.yaml`

It also adds the current working directory as a search path which was the main reason why the runscript was failing to find the `fesom_output_control.yaml` file.

PS: the commits are very dirty, I should have stashed them instead of making intermediate commits. Sorry 😞 