### PR TITLE
hotfix/look for file

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.4"
+__version__ = "5.1.5"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -177,13 +177,11 @@ def look_for_file(model, item):
     ]
 
     endings = [ "", ".yaml", ".yml", ".YAML", ".YML" ]
-    
+
     for possible_path in possible_paths:
-        # first strip off any file extensions and add the current one
-        root_name = os.path.splitext(possible_path)[0]
 
         for ending in endings:
-            file_path = root_name + ending
+            file_path = possible_path + ending
 
             # Check if the file exists and if it does return its path
             if os.path.isfile(file_path):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.4
+current_version = 5.1.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.4",
+    version="5.1.5",
     zip_safe=False,
 )


### PR DESCRIPTION
The previous hotfix introduced the following lines:
https://github.com/esm-tools/esm_parser/blob/11de697ee5e245eb01b5eaec679820b9874b9152/esm_parser/esm_parser.py#L179-L186

When running `esm_runscripts` for `awicm3` the `fesom-2.0` file is searched. That makes `possible_path` to take the value `<path_to_components>/fesom/fesom-2.0`>. When `root_name = os.path.splitext(possible_path)[0] ` is evaluated `root_name` is `<path_to_components>/fesom/fesom-2` (missing the `.0` at the end). Note that this file does not exist, and won't be found, meaning that `fesom.yaml` will be loaded instead of `fesom-2.0.yaml`.

This fix removes the `root_name = os.path.splitext(possible_path)[0]` cause it is not necessary to remove the extension as one of the `endings` is already an empty string.