### PR TITLE
hotfix/add include models

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.5"
+__version__ = "5.1.6"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -1414,10 +1414,10 @@ def resolve_choose_with_var(
 ):
     """
     Searches for a ``choose_`` block inside a model configuration ``config``, in which
-    ``var`` is defined, and then resolves ONLY the ``var`` (the other variables in the
-    ``choose_`` remain untouched). Needed, for example, for being able to use
-    ``include_models`` from a ``choose_`` before the general choose-resolve takes place
-    (i.e. include ``xios`` component from ``oifs.yaml`` using a ``choose_``).
+    ``var`` is defined, and then resolves ONLY the ``var`` and ``add_<var>`` (the other
+    variables in the ``choose_`` remain untouched). Needed, for example, for being able
+    to use ``include_models`` from a ``choose_`` before the general choose-resolve takes
+    place (i.e. include ``xios`` component from ``oifs.yaml`` using a ``choose_``).
 
     Parameters
     ----------
@@ -1448,6 +1448,7 @@ def resolve_choose_with_var(
     )
     choose_with_add_var = [x for x in choose_with_add_var if "choose_" in x]
 
+    # Resolve first for ``<var>`` and then for ``add_<var>``
     for choose_with_var, lvar in [
         (choose_with_var, var), (choose_with_add_var, f"add_{var}")
     ]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.5
+current_version = 5.1.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.5",
+    version="5.1.6",
     zip_safe=False,
 )


### PR DESCRIPTION
`include_models` variable in `choose_` blocks is solved relatively early in the parser so that the building information is avialable for `esm_master`. `add_include_models` variable was not resolved following this strategy and therefore, having an `add_include_models` inside a `choose_` block was not making any effect, for example, in `awicm3.yaml`:
```
general:
    choose_version:
          1.0-frontiers-xios:
            couplings:
            - fesom-2.0-frontiers+oifs-43r3-awi-frontiers-xios+xios-2.5
            add_include_models:
            - xios
```

In this case, compilation info in the `xios.yaml` file was not available because the `add_include_models` had no effect.

Now, `add_include_models` is resolved early following the same strategy as for `include_models`.