### PR TITLE
solving the problems created by the previous nested_adds implementati…

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.7"
+__version__ = "5.1.8"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -2643,18 +2643,30 @@ class ConfigSetup(GeneralConfig):  # pragma: no cover
             user_config["defaults"] = {}
 
         default_infos = {}
-        for i in os.listdir(DEFAULTS_DIR):
-            file_contents = yaml_file_to_dict(DEFAULTS_DIR + "/" + i)
+
+        # get the files in the defaults directory and exclude general.yaml 
+        yaml_files = os.listdir(DEFAULTS_DIR)
+        if 'general.yaml' in yaml_files:
+            yaml_files.remove('general.yaml')
+            
+        for yaml_file in yaml_files: 
+            file_contents = yaml_file_to_dict(DEFAULTS_DIR + "/" + yaml_file)
             default_infos.update(file_contents)
 
-
+        # construct the `defaults` section of the configuration
         user_config["defaults"].update(default_infos)
 
         computer_file = determine_computer_from_hostname()
         computer_config = yaml_file_to_dict(computer_file)
+        
+        if 'general.yaml' in os.listdir(DEFAULTS_DIR):
+            general_config = yaml_file_to_dict(f"{DEFAULTS_DIR}/general.yaml")
+        else:
+            general_config = {}
+        
         setup_config = {
             "computer": computer_config,
-            "general": {},
+            "general": general_config,
         }
         for attachment in CONFIGS_TO_ALWAYS_ATTACH_AND_REMOVE:
             attach_to_config_and_remove(setup_config["computer"], attachment,

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -626,7 +626,9 @@ def dict_merge(dct, merge_dct):
         elif (
             isinstance(k, str)
             and k.startswith("add_")
-            and isinstance(v, (list, dict))
+            and "module_actions" not in k
+            and "export_vars" not in k
+            and isinstance(v, (list))
         ):
             add_entries_from_chapter(dct, "".join(k.split("add_")), v)
         else:

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -139,6 +139,8 @@ constant_blacklist = [r"PATH", r"LD_LIBRARY_PATH", r"NETCDFF_ROOT", r"I_MPI_ROOT
 
 constant_blacklist = [re.compile(entry) for entry in constant_blacklist]
 
+protected_adds = ["add_module_actions", "add_export_vars", "add_unset_vars"]
+
 # Ensure FileNotFoundError exists:
 if six.PY2:  # pragma: no cover
     FileNotFoundError = IOError
@@ -630,8 +632,7 @@ def dict_merge(dct, merge_dct, resolve_nested_adds=False):
             resolve_nested_adds
             and isinstance(k, str)
             and k.startswith("add_")
-            and "module_actions" not in k
-            and "export_vars" not in k
+            and k not in protected_adds
             and isinstance(v, (list, dict))
         ):
             add_entries_from_chapter(dct, "".join(k.split("add_")), v)
@@ -790,7 +791,11 @@ def add_entries_from_chapter(config, add_chapter, add_entries):
                 config[add_chapter].append(entry)
         elif type(config[add_chapter]) == dict:
             # MA: I'm not supper happy about the resolve_nested_adds implementation
-            dict_merge(config[add_chapter], add_entries, resolve_nested_adds=True)
+            dict_merge(
+                config[add_chapter],
+                add_entries,
+                resolve_nested_adds=True,
+            )
     else:
         config[add_chapter] = add_entries
 

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -614,7 +614,7 @@ def dict_merge(dct, merge_dct, resolve_nested_adds=False):
             #
             # An idea...but I have absolutely no clue how to cleanly implement that...
             if k is not "debug_info":
-                dict_merge(dct[k], merge_dct[k])
+                dict_merge(dct[k], merge_dct[k], resolve_nested_adds)
             else:
                 if "debug_info" in dct:
                     if isinstance(dct["debug_info"]["loaded_from_file"], str):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.7
+current_version = 5.1.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.7",
+    version="5.1.8",
     zip_safe=False,
 )


### PR DESCRIPTION
It went easily unnoticed, but the changes of #62 in the `dict_merge` method, deeply modified the behavior of such a method and the order in which already supported nested `add_`s (such as `add_export_vars` or `add_module_actions`) were resolved. Therefore, this fix should bring back the old behavior of `dict_merge` while providing a solution to what was to be accomplished in #62.