### PR TITLE
bugfix for esm_master issue 57

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.8"
+__version__ = "5.1.9"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -72,6 +72,7 @@ import subprocess
 import sys
 import warnings
 import numpy
+from numbers import Number
 
 # Always import externals before any non standard library imports
 
@@ -2294,7 +2295,9 @@ def perform_actions(tree, rhs, config):
               action, parameter = action.split("(")
           if "format" in action:
               if "d" in parameter or "f" in parameter:
-                  source = int(source)
+                  # if the string resembles a float (eg. 366.0), then first 
+                  # turn it into a float and then to an int to prevent crash
+                  source = int(float(source))
               if parameter:
                   solved_rhs = parameter % source
               else:
@@ -2347,29 +2350,32 @@ def could_be_bool(value):
     return False
 
 
-def could_be_int(value):
-    try:
-        int(value)
-        return contains_underscore(value)
-    except:
-        try:
-            intval = int(
-                float(value)
-            )  # that is actually necessary, because of int("48.0")
-            if intval - float(value) == 0.0:
-                return contains_underscore(value)
-            else:
-                return False
-        except:
-            return False
+def could_be_int(entry):
+    """checks if the string input is an integer"""
+    is_int = False
+    # if not isinstance(entry, Number):
+        # return False
+    pattern = "[+-]?[0-9][0-9]*"
+    entry_str = str(entry)
+    m = re.match(pattern, entry_str)
+    if m:
+        if m.group(0) == entry_str:
+            is_int = True
+    return is_int
 
 
-def could_be_float(value):
-    try:
-        float(value)
-        return contains_underscore(value)
-    except:
-        return False
+def could_be_float(entry):
+    """checks if the string input is an floating point number"""
+    is_float = False
+    # if not isinstance(entry, Number):
+        # return False
+    entry_str = str(entry)
+    pattern = "([+-]?[0-9]+)?\.([0-9]*)?([Ee][+-]?[0-9]+)?"
+    m = re.match(pattern, entry_str)
+    if m:
+        if m.group(0) == entry_str:
+            is_float = True
+    return is_float
 
 
 def could_be_complex(value):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.8
+current_version = 5.1.9
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.8",
+    version="5.1.9",
     zip_safe=False,
 )


### PR DESCRIPTION
fixes the issue: https://github.com/esm-tools/esm_master/issues/57

math functions in the parser convert numbers like "4.0" to 4, which breaks down the version or branch names. The new interface uses regex instead of casting. I tested my functions with unit tests and I will also push these tests later on. As a future goal, I would like to write detailed unit tests for the all parser functions.

This bug fix must be merged together with the `esm_master` pull request: https://github.com/esm-tools/esm_parser/pull/69