### PR TITLE
Hotfix/revert 5.1.9 prov solution4branch

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.10"
+__version__ = "5.1.11"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -138,6 +138,8 @@ constant_blacklist = [r"PATH", r"LD_LIBRARY_PATH", r"NETCDFF_ROOT", r"I_MPI_ROOT
 
 constant_blacklist = [re.compile(entry) for entry in constant_blacklist]
 
+keep_as_str = ["branch", "version"]
+
 # Ensure FileNotFoundError exists:
 if six.PY2:  # pragma: no cover
     FileNotFoundError = IOError
@@ -2210,7 +2212,10 @@ def do_math_in_entry(tree, rhs, config):
             result = result[-1] # should be extended in the future - here: if list (= if diff between dates) than result in seconds
         result = str(result)
         entry = before_math + result + after_math
-    return convert(entry.strip())
+    # TODO MA: this is a provisional dirty fix for release. Get rid of this once a more
+    # general solution is worked out
+    # ORIGINAL LINE: return convert(entry.strip())
+    return convert(entry.strip(), tree)
 
 
 def mark_dates(tree, rhs, config):
@@ -2387,7 +2392,14 @@ def contains_underscore(value):
     return True
 
 
-def convert(value):
+# TODO MA: this is a provisional dirty fix for release. Get rid of this once a more
+# general solution is worked out
+# ORIGINAL LINE: def convert(value):
+def convert(value, tree=["NO_KEY"]):
+    if tree:
+        key = tree[-1]
+        if key in keep_as_str:
+            return value
     if could_be_bool(value):
         return to_boolean(value)
     elif could_be_int(value):

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -72,7 +72,6 @@ import subprocess
 import sys
 import warnings
 import numpy
-from numbers import Number
 
 # Always import externals before any non standard library imports
 
@@ -2295,9 +2294,7 @@ def perform_actions(tree, rhs, config):
               action, parameter = action.split("(")
           if "format" in action:
               if "d" in parameter or "f" in parameter:
-                  # if the string resembles a float (eg. 366.0), then first 
-                  # turn it into a float and then to an int to prevent crash
-                  source = int(float(source))
+                  source = int(source)
               if parameter:
                   solved_rhs = parameter % source
               else:
@@ -2350,32 +2347,29 @@ def could_be_bool(value):
     return False
 
 
-def could_be_int(entry):
-    """checks if the string input is an integer"""
-    is_int = False
-    # if not isinstance(entry, Number):
-        # return False
-    pattern = "[+-]?[0-9][0-9]*"
-    entry_str = str(entry)
-    m = re.match(pattern, entry_str)
-    if m:
-        if m.group(0) == entry_str:
-            is_int = True
-    return is_int
+def could_be_int(value):
+    try:
+        int(value)
+        return contains_underscore(value)
+    except:
+        try:
+            intval = int(
+                float(value)
+            )  # that is actually necessary, because of int("48.0")
+            if intval - float(value) == 0.0:
+                return contains_underscore(value)
+            else:
+                return False
+        except:
+            return False
 
 
-def could_be_float(entry):
-    """checks if the string input is an floating point number"""
-    is_float = False
-    # if not isinstance(entry, Number):
-        # return False
-    entry_str = str(entry)
-    pattern = "([+-]?[0-9]+)?\.([0-9]*)?([Ee][+-]?[0-9]+)?"
-    m = re.match(pattern, entry_str)
-    if m:
-        if m.group(0) == entry_str:
-            is_float = True
-    return is_float
+def could_be_float(value):
+    try:
+        float(value)
+        return contains_underscore(value)
+    except:
+        return False
 
 
 def could_be_complex(value):

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -138,7 +138,7 @@ constant_blacklist = [r"PATH", r"LD_LIBRARY_PATH", r"NETCDFF_ROOT", r"I_MPI_ROOT
 
 constant_blacklist = [re.compile(entry) for entry in constant_blacklist]
 
-keep_as_str = ["branch", "version"]
+keep_as_str = ["branch"]
 
 # Ensure FileNotFoundError exists:
 if six.PY2:  # pragma: no cover

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.10
+current_version = 5.1.11
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.10",
+    version="5.1.11",
     zip_safe=False,
 )


### PR DESCRIPTION
Reverting back changes in 5.1.9 and adding a provisional solution that avoids changing `branch` and `version` variables into a `int` or a `float`, so that they remain as `str`.

Tested for:
- AWICM-1
- AWICM-2
- FESOM-2
- FESOM-1.4-REcoM