### PR TITLE
added dont_overwrite_with_empty_value to prevent overwriting when req…

### DIFF
--- a/esm_parser/__init__.py
+++ b/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.11"
+__version__ = "5.1.12"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/esm_parser/esm_parser.py
+++ b/esm_parser/esm_parser.py
@@ -431,7 +431,7 @@ def attach_to_config_and_reduce_keyword(
         del config_to_read_from[full_keyword]
 
 
-def attach_single_config(config, path, attach_value, all_config=None):
+def attach_single_config(config, path, attach_value, all_config=None, **kwargs):
     """
     Parameters
     ----------
@@ -456,11 +456,11 @@ def attach_single_config(config, path, attach_value, all_config=None):
         print ("Could not find ", path + "/" + attach_value)
         sys.exit(1)
     #DB this is a try:
-    dict_merge(config, attachable_config)
+    dict_merge(config, attachable_config, **kwargs)
     #config.update(attachable_config)
 
 
-def attach_to_config_and_remove(config, attach_key, all_config=None):
+def attach_to_config_and_remove(config, attach_key, all_config=None, **kwargs):
     """
     Attaches extra dict to this one and removes the chapter
 
@@ -489,7 +489,7 @@ def attach_to_config_and_remove(config, attach_key, all_config=None):
                 attach_path, attach_value = attach_value.rsplit("/", 1)
             except ValueError:
                 attach_path = "."
-            attach_single_config(config, attach_path, attach_value, all_config=all_config)
+            attach_single_config(config, attach_path, attach_value, all_config=all_config, **kwargs)
 
 
 priority_marker = ">>THIS_ONE<<"
@@ -579,7 +579,7 @@ def new_deep_update(receiving_dict, dict_to_be_included, winner = "receiving", b
 
 
 
-def dict_merge(dct, merge_dct):
+def dict_merge(dct, merge_dct, **kwargs):
     """ Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
     updating only top-level keys, dict_merge recurses down into dicts nested
     to an arbitrary depth, updating keys. The ``merge_dct`` is merged into
@@ -588,6 +588,11 @@ def dict_merge(dct, merge_dct):
     :param merge_dct: dct merged into dct
     :return: None
     """
+    # option to overwrite a dict value if merge_dict contains empty value. Default
+    # is False
+    dont_overwrite_with_empty_value = kwargs.get("dont_overwrite_with_empty_value", 
+        False)
+
     for k, v in six.iteritems(merge_dct):
         if (
             k in dct
@@ -623,6 +628,12 @@ def dict_merge(dct, merge_dct):
                     else:
                         dct["debug_info"]["loaded_from_file"].append(merge_dct["debug_info"]["loaded_from_file"])
         else:
+            # keep the value of dct[k] if dct[k] is already set but merge_dct[k]
+            # is empty and protection is requested
+            if k in dct:
+                if dct[k] and not merge_dct[k] and dont_overwrite_with_empty_value:
+                    merge_dct[k] = dct[k]
+
             dct[k] = merge_dct[k]
 
 
@@ -2682,7 +2693,7 @@ class ConfigSetup(GeneralConfig):  # pragma: no cover
         }
         for attachment in CONFIGS_TO_ALWAYS_ATTACH_AND_REMOVE:
             attach_to_config_and_remove(setup_config["computer"], attachment,
-                all_config = None)
+                all_config = None, dont_overwrite_with_empty_value=True)
         # Add the fake "model" name to the computer:
         setup_config["computer"]["model"] = "computer"
         logger.info("setup config is being updated with setup_relevant_configs")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.11
+current_version = 5.1.12
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://gitlab.awi.de/esm_tools/esm_parser',
-    version="5.1.11",
+    version="5.1.12",
     zip_safe=False,
 )


### PR DESCRIPTION
Hi @seb-wahl,

this hotfix branch will solve your issue https://github.com/esm-tools/esm_runscripts/issues/184

### Description of the problem:
When `additional_flags` are provided in a machine file (eg. `mistral.yaml`, `ollie.yaml`), they don't get into the `finished_config.yaml` and sad file.

The reason is `additional_flags` is also set in `slurm.yaml` (as an empty string) and overwrites what is provided in the machine file. This happens inside the parser. @mandresm told me that `additional_flags` should be set in `slurm.yaml` but how can we preserve it when provided in a machine file?

### Solution:
Here is the call tree in the parser:
```python
2684             attach_to_config_and_remove(setup_config["computer"], attachment, all_config = None)

463 def attach_to_config_and_remove(config, attach_key, all_config=None):
492             attach_single_config(config, attach_path, attach_value, all_config=all_config)

434 def attach_single_config(config, path, attach_value, all_config=None):
459     dict_merge(config, attachable_config)

582 def dict_merge(dct, merge_dct):
    dct[k] = merge_dct[k]
```
So, the `attachment` (`further_reading` -> `slurm.yaml`) will always prevail if it has the same key in the machine yaml file.

I tried to implement a solution which improves this behaviour without breaking it. When the keyword argument `dont_overwrite_with_empty_value=True` is provided it will check if 
- the dict to be overwritten contains that key
- its value is not empty
- dict to overwrite has empty value (eg. empty string)

and protect the value in the machine yaml file.

I made some tests:
1. Default case:
`esm_runscripts fesom2-ollie-initial-monthly.yaml -c`
`-> test_finished_config_1.yaml` 

2. added `additional_flags: "--mem=0"` to `ollie.yaml`
`esm_runscripts fesom2-ollie-initial-monthly.yaml -c`
`-> test_finished_config_2.yaml`
**diff:** only jobids, the additions don't go into the finished yaml file

3. switch to the bugfix branch
`esm_runscripts fesom2-ollie-initial-monthly.yaml -c`
`-> test_finished_config_3.yaml`
**diff:** `"additional_flags: --mem=0"` is preserved
```diff
5c5
<     additional_flags: ''
---
>     additional_flags: --mem=0
658c658
<     jobid: 157702
---
>     jobid: 1926
```


4. Try with `additional_flags` you had in https://github.com/esm-tools/esm_runscripts/issues/184
`esm_runscripts fesom2-ollie-initial-monthly.yaml -c`
`-> test_finished_config_4.yaml`
**diff:** 
```diff
5c5,7
<     additional_flags: ''
---
>     additional_flags:
>     - --mem=72000
>     - --contraint="cascade"
658c660
<     jobid: 157702
---
>     jobid: 10427
```

I tested these in both `ollie` and `mistral`. Could you please try them on your machine? Miguel is away this week so, I will probably merge these when he returns. So far the tests are fine. I don't think that they will break anything 🤞 